### PR TITLE
Update index.md

### DIFF
--- a/Working-Sessions/Owasp-Top-10-2017/index.md
+++ b/Working-Sessions/Owasp-Top-10-2017/index.md
@@ -5,5 +5,5 @@ type         : track
 technology   :
 description  : Owasp Top 2017 RC1 is out and the Summit is the location to debate it and agree on the final list
 organizers   : Dave Wichers
-participants : Bjoern Kimminich,Marc Rimbau,Brian Glas,Felipe Zipitria,Mateo Martinez,Scott Treacy
+participants : Bjoern Kimminich,Marc Rimbau,Brian Glas,Felipe Zipitria,Mateo Martinez,Scott Treacy,Ade Yoseman Putra
 ---


### PR DESCRIPTION
---
layout       : blocks/track
title        : Owasp Top 10 2017
type         : track
technology   :
description  : Owasp Top 2017 RC1 is out and the Summit is the location to debate it and agree on the final list
organizers   : Dave Wichers
participants : Bjoern Kimminich,Marc Rimbau,Brian Glas,Felipe Zipitria,Mateo Martinez,Scott Treacy,Ade Yoseman Putra
---