### PR TITLE
Update AppSec-BSc-Masters-Curriculum-Design.md

### DIFF
--- a/Working-Sessions/Education/AppSec-BSc-Masters-Curriculum-Design.md
+++ b/Working-Sessions/Education/AppSec-BSc-Masters-Curriculum-Design.md
@@ -7,7 +7,7 @@ track        : Education
 when-day     : Wed
 description  : Part of OWASP's main purpose is to "Be the thriving global community that drives visibility and evolution in the safety and security of the world’s software" and a key part of that mission is to educate not just the current generation of developers or information security professionals but also the next generation as well especially with the acknowledged skill shortage in the whole sector that exists.
 organizers   : Adrian Winckles,Felipe Zipitria
-participants : Timo Pagel,Bjoern Kimminich
+participants : Timo Pagel,Bjoern Kimminich,Ade Yoseman Putra
 
 ---
 ## Why


### PR DESCRIPTION
---
layout       : blocks/working-session
title        : Application Security BSc/Masters Curriculum Design
type         : workshop
status       : featured
track        : Education
when-day     : Wed
description  : Part of OWASP's main purpose is to "Be the thriving global community that drives visibility and evolution in the safety and security of the world’s software" and a key part of that mission is to educate not just the current generation of developers or information security professionals but also the next generation as well especially with the acknowledged skill shortage in the whole sector that exists.
organizers   : Adrian Winckles,Felipe Zipitria
participants : Timo Pagel,Bjoern Kimminich,Ade Yoseman Putra

---
## Why

This Working Session will explore the possibility of OWASP developing an educational strategy for security programmes at both undergraduate and postgraduate levels.

Part of OWASP's main purpose is to _"Be the thriving global community that drives visibility and evolution in the safety and security of the world’s software"_. A key part of that mission is to educate not just the current generation of developers or information security professionals, but also the next generation, particularly in the context of the acknowledged skills shortage in the security sector.

A common problem with many security education programmes (whether cyber or InfoSec) or even traditional computer science programmes is that they do not address application security adequately, if at all.  In some regions, attempts have been made to address this deficit.  In the UK for example, ISC2 and the BCS are working on an initiative to embed security firmly within the Computer Science curriculum, with an emphasis on secure coding techniques. OWASP, through my involvement, also champions this initiative.

There is an opportunity for OWASP to pull together its wide-ranging expertise, projects, and dedicated volunteers to engage in these types of education programmes and initiatives by developing an educational strategy for undergraduate and postgraduate students. This could take the form of an open "Standard" template which can be adopted and adapted by diverse educational partners and organisations. Such a template would also give a useful starting point or reference document for when we engage with other professional bodies.

## What

- What aspects of Application Security knowledge and skills does industry need?
- What problems relating to application security does the next generation of graduate software developers, computer scientists and security analysts need to solve?
- Establish a core set of learning objectives for BSC/MSc level Application Security curricula.
- Establish which OWASP Projects are useful to help shape and support curricula in Application Security.
- Determine a mechanism by which regional/local deliveries of the curriculum could be supported by the OWASP community (for example, OWASP supporters on validation panels, critical friend on module design, guest lectures and training academics)

## Who

The target audience for this Working Session is:

- OWASP project leaders whose projects have an educational element (probably all OWASP Project leaders)
- Application Security Trainers  
- Academics involved in AppSec and InfoSec 
- Any employer involved in recruiting graduates into application security related roles
- Other organisations/professional bodies with a vested interest in application security educational programmes